### PR TITLE
Make sure we can also read packages that have a guarded setup function

### DIFF
--- a/setupreader.py
+++ b/setupreader.py
@@ -42,9 +42,10 @@ def load(path):
         # if __name__ == '__main__'
 
         # let's try to find a function that looks like it guards setup.
-        functions = inspect.getmembers(setup_module, inspect.isfunction)
-        for name, fun in functions:
-            argspec = inspect.getargspec(fun)
+        functions_found_in_setup_module = inspect.getmembers(
+            setup_module, inspect.isfunction)
+        for name, candidate in functions_found_in_setup_module:
+            argspec = inspect.getargspec(candidate)
             # if the function is named 'main' and it receives no arguments, we
             # declare it found.
             # Also if this package was made by peopls without any knowledge or
@@ -52,9 +53,9 @@ def load(path):
             # something else as main. We will declare any function that is
             # defined inside the setup_module that received no arguments as a
             # find.
-            if (name == 'main' or inspect.getmodule(fun) == setup_module) and \
+            if (name == 'main' or inspect.getmodule(candidate) == setup_module) and \
                 len(argspec.args) == 0:
-                fun()
+                candidate()
                 break
         else: # we couldn't find anything resembling a guarded setup function.
             raise BrokenSetupException()

--- a/setupreader.py
+++ b/setupreader.py
@@ -1,9 +1,30 @@
+import inspect
 import imp
 import json
 import functools
 import argparse
 
 import mock
+
+class BrokenSetupException(Exception):
+    """
+    setupreader can not find a setup function in your setup.py.
+
+    please make sure your setup.py contains the call to setup.
+    If you have placed a guard around the call to setup like this::
+    
+        def main():
+            setup(
+                ...
+            )
+
+        if __name__ == '__main__':
+            main()
+    
+    make sure the guarding function takes no parameters.
+    """
+    def __init__(self):
+        super(BrokenSetupException, self).__init__(self.__doc__)
 
 
 def _setup(target, *args, **kwargs):
@@ -14,9 +35,32 @@ def load(path):
     setupdict = argparse.Namespace(result=None)
 
     with mock.patch('setuptools.setup', functools.partial(_setup, setupdict)):
-        imp.load_source('packagesetup', path)
+        setup_module = imp.load_source('packagesetup', path)
 
-    return setupdict.result
+    if setupdict.result is None:
+        # this can happen if the call to setup is inside a guard:
+        # if __name__ == '__main__'
+
+        # let's try to find a function that looks like it guards setup.
+        functions = inspect.getmembers(setup_module, inspect.isfunction)
+        for name, fun in functions:
+            argspec = inspect.getargspec(fun)
+            # if the function is named 'main' and it receives no arguments, we
+            # declare it found.
+            # Also if this package was made by peopls without any knowledge or
+            # feeling for python idioms, they might have named it
+            # something else as main. We will declare any function that is
+            # defined inside the setup_module that received no arguments as a
+            # find.
+            if (name == 'main' or inspect.getmodule(fun) == setup_module) and \
+                len(argspec.args) == 0:
+                fun()
+                break
+        else: # we couldn't find anything resembling a guarded setup function.
+            raise BrokenSetupException()
+                
+
+        return setupdict.result
 
 
 def main():


### PR DESCRIPTION
some (shit) packages has code like this in setup.py:

```
def main():
    setup(...)

if __name__ == '__main__':
    main()
```

this patch make setupreader able to detect this and still get the settings
